### PR TITLE
Bump teachbooks-questions to version 0.2.0 in all-deps group

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,8 +30,8 @@ dependencies = [
     "sphinx-launch-buttons==v1.0.7",
     "sphinx-github-alerts==v1.1",
     "sphinx-metadata-figure==v1.5.1",
-    # waiting for merge of https://github.com/mgeier/sphinx-last-updated-by-git/pull/102,
-    "sphinx-last-updated-by-git @ git+https://github.com/TeachBooks/sphinx-last-updated-by-git@999e829", #
+    # waiting for merge of https://github.com/mgeier/sphinx-last-updated-by-git/pull/97,
+    "sphinx-last-updated-by-git @ git+https://github.com/TeachBooks/sphinx-last-updated-by-git@986142b",
     "sphinx-gated-directives==v1.1.2",
     "teachbooks-zoomies==0.2.4",
     "teachbooks-questions==0.2.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "sphinx-last-updated-by-git @ git+https://github.com/TeachBooks/sphinx-last-updated-by-git@986142b",
     "sphinx-gated-directives==v1.1.2",
     "teachbooks-zoomies==0.2.4",
-    "teachbooks-questions==0.1.6",
+    "teachbooks-questions==0.2.0",
     "sphinx-sticky-margin==1.1.3"
 ]
 


### PR DESCRIPTION
This pull request updates the `teachbooks-questions` package dependency to a newer version in the `pyproject.toml` file.

Dependency updates:

* Bumped the `teachbooks-questions` dependency from version `0.1.6` to `0.2.0` in `pyproject.toml` to ensure the project uses the latest features and fixes.