### PR TITLE
Add teachbooks-fetch dependency and extension to setup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,8 @@ dependencies = [
     "sphinx-gated-directives==v1.1.2",
     "teachbooks-zoomies==0.2.4",
     "teachbooks-questions==0.2.0",
-    "sphinx-sticky-margin==1.1.3"
+    "sphinx-sticky-margin==1.1.3",
+    "teachbooks-fetch==0.0.1"
 ]
 
 requires-python = ">=3.10"

--- a/src/teachbooks_favourites/__init__.py
+++ b/src/teachbooks_favourites/__init__.py
@@ -32,6 +32,7 @@ def setup(app: Sphinx) -> Dict[str, Any]:
     app.setup_extension("teachbooks_zoomies")
     app.setup_extension("teachbooks_questions")
     app.setup_extension("sphinx_sticky_margin")
+    app.setup_extension("teachbooks_fetch")
     
     return {
         "version": "builtin",


### PR DESCRIPTION
This pull request adds support for the new `teachbooks_fetch` extension to the project. The main changes involve updating dependencies and ensuring the extension is initialized with Sphinx.

Dependency and extension updates:

* Added `teachbooks-fetch==0.0.1` to the `dependencies` list in `pyproject.toml` to ensure the package is installed.
* Registered the `teachbooks_fetch` extension in the Sphinx setup function in `src/teachbooks_favourites/__init__.py`, so it is loaded automatically.